### PR TITLE
fix(tunnel): reverse proxy explicit http targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,11 @@ sealtun expose 3000
 
 # 也可以把公网 HTTPS 入口转发到当前机器可访问的 HTTP upstream
 sealtun expose --target http://10.0.0.12:8080
+sealtun expose --target https://10.0.0.12:8443/admin
 
 ```
 
-`--target` 只适用于默认 HTTPS 隧道，目标必须是运行 Sealtun CLI 的机器可访问的 `http://` 或 `https://` 地址；SSH/TCP 四层隧道仍使用本地端口和 NodePort 模型。
+`--target` 只适用于默认 HTTPS 隧道，目标必须是运行 Sealtun CLI 的机器可访问的 `http://` 或 `https://` 地址；可带 path 作为 upstream base path，例如公开访问 `/api` 会转发到 `https://10.0.0.12:8443/admin/api`。SSH/TCP 四层隧道仍使用本地端口和 NodePort 模型。
 
 为公网业务流量启用 Basic Auth：
 ```bash
@@ -519,7 +520,7 @@ tunnels:
 version: v1
 tunnels:
   - name: upstream-api
-    target: http://10.0.0.12:8080
+    target: https://10.0.0.12:8443/admin
     protocol: https
 ```
 
@@ -563,7 +564,7 @@ basicAuth:
   passwordEnv: SEALTUN_BASIC_AUTH_PASSWORD
 ```
 
-`name` 会作为稳定 tunnel ID 使用，因此重复执行 `apply` 会更新同一个 `sealtun-<name>` 资源。`tunnels` 支持一次声明多条隧道；`target` 只支持 HTTPS 隧道，目标必须是 `http://` 或 `https://` URL，如果同时写 `localPort`，端口必须和 `target` 端口一致。`ttl` 会写入本地 session 的 `expiresAt`，本地 daemon 发现过期后会自动删除远端资源和本地记录。自定义域名仍然遵循 CNAME 先验证再绑定的规则；新隧道如果 CNAME 未就绪，`apply` 会先保留 Sealos 官方域名并输出后续 `domain set` 指令；已有隧道则会拒绝未验证的自定义域名变更，避免误清理或覆盖正在使用的域名配置。
+`name` 会作为稳定 tunnel ID 使用，因此重复执行 `apply` 会更新同一个 `sealtun-<name>` 资源。`tunnels` 支持一次声明多条隧道；`target` 只支持 HTTPS 隧道，目标必须是 `http://` 或 `https://` URL，可带 path 作为 upstream base path，但不能包含 query、fragment 或 userinfo；如果同时写 `localPort`，端口必须和 `target` 端口一致。`ttl` 会写入本地 session 的 `expiresAt`，本地 daemon 发现过期后会自动删除远端资源和本地记录。自定义域名仍然遵循 CNAME 先验证再绑定的规则；新隧道如果 CNAME 未就绪，`apply` 会先保留 Sealos 官方域名并输出后续 `domain set` 指令；已有隧道则会拒绝未验证的自定义域名变更，避免误清理或覆盖正在使用的域名配置。
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -189,10 +189,11 @@ sealtun expose 3000
 
 # Or forward the public HTTPS entry to an HTTP upstream reachable from this machine
 sealtun expose --target http://10.0.0.12:8080
+sealtun expose --target https://10.0.0.12:8443/admin
 
 ```
 
-`--target` applies only to default HTTPS tunnels. The target must be a `http://` or `https://` address reachable from the machine running the Sealtun CLI. SSH/TCP L4 tunnels continue to use the local port plus NodePort model.
+`--target` applies only to default HTTPS tunnels. The target must be a `http://` or `https://` address reachable from the machine running the Sealtun CLI. It may include a path as the upstream base path, so public `/api` is forwarded to `https://10.0.0.12:8443/admin/api`. SSH/TCP L4 tunnels continue to use the local port plus NodePort model.
 
 Enable Basic Auth for public application traffic:
 ```bash
@@ -519,7 +520,7 @@ Remote HTTP upstreams can use `target` without a local listening port:
 version: v1
 tunnels:
   - name: upstream-api
-    target: http://10.0.0.12:8080
+    target: https://10.0.0.12:8443/admin
     protocol: https
 ```
 
@@ -563,7 +564,7 @@ basicAuth:
   passwordEnv: SEALTUN_BASIC_AUTH_PASSWORD
 ```
 
-`name` is used as the stable tunnel ID, so repeated `apply` runs update the same `sealtun-<name>` resources. `tunnels` can declare multiple tunnels in one file. `target` is HTTPS-only and must be a `http://` or `https://` URL; if `localPort` is also set, it must match the target port. `ttl` is persisted as `expiresAt` in the local session; the local daemon automatically removes expired remote resources and session records. Custom domains still require verified CNAME ownership before attachment; for a new tunnel, `apply` keeps the Sealos-managed host and prints the follow-up `domain set` command when DNS is not ready. For an existing tunnel, `apply` rejects unverified custom-domain changes so it does not accidentally clear or overwrite a working domain configuration.
+`name` is used as the stable tunnel ID, so repeated `apply` runs update the same `sealtun-<name>` resources. `tunnels` can declare multiple tunnels in one file. `target` is HTTPS-only and must be a `http://` or `https://` URL; it may include a path as the upstream base path, but cannot include query, fragment, or userinfo. If `localPort` is also set, it must match the target port. `ttl` is persisted as `expiresAt` in the local session; the local daemon automatically removes expired remote resources and session records. Custom domains still require verified CNAME ownership before attachment; for a new tunnel, `apply` keeps the Sealos-managed host and prints the follow-up `domain set` command when DNS is not ready. For an existing tunnel, `apply` rejects unverified custom-domain changes so it does not accidentally clear or overwrite a working domain configuration.
 
 ## License
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -162,6 +162,18 @@ func TestNormalizeApplyTunnelAcceptsHTTPUpstreamTarget(t *testing.T) {
 	}
 }
 
+func TestNormalizeApplyTunnelAcceptsHTTPUpstreamTargetSubRoute(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := normalizeApplyTunnel(applyTunnel{Name: "api", Target: "https://192.168.10.70.nip.io/admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized.LocalPort != "443" || normalized.TargetURL != "https://192.168.10.70.nip.io:443/admin" {
+		t.Fatalf("unexpected target normalization: %#v", normalized)
+	}
+}
+
 func TestNormalizeApplyTunnelRejectsMismatchedLocalPortAndTarget(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/expose_test.go
+++ b/cmd/expose_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/labring/sealtun/pkg/tunnel"
+)
 
 func TestValidateLocalPort(t *testing.T) {
 	t.Parallel()
@@ -59,6 +63,34 @@ func TestResolveExposeTargetAcceptsRemoteHTTPUpstream(t *testing.T) {
 	}
 	if localPort != "8080" || targetURL != "http://10.0.0.12:8080" {
 		t.Fatalf("unexpected remote target: localPort=%s target=%s", localPort, targetURL)
+	}
+}
+
+func TestResolveExposeTargetAcceptsRemoteHTTPUpstreamSubRoute(t *testing.T) {
+	t.Parallel()
+
+	localPort, targetURL, err := resolveExposeTarget(nil, "https://192.168.10.70.nip.io/admin")
+	if err != nil {
+		t.Fatalf("resolve remote target: %v", err)
+	}
+	if localPort != "443" || targetURL != "https://192.168.10.70.nip.io:443/admin" {
+		t.Fatalf("unexpected remote target: localPort=%s target=%s", localPort, targetURL)
+	}
+}
+
+func TestResolveExposeTargetDefaultHTTPSPortKeepsHostHeaderStable(t *testing.T) {
+	t.Parallel()
+
+	_, targetURL, err := resolveExposeTarget(nil, "https://192.168.10.70.nip.io/")
+	if err != nil {
+		t.Fatalf("resolve remote target: %v", err)
+	}
+	target, err := tunnel.TargetFor("", targetURL)
+	if err != nil {
+		t.Fatalf("parse persisted target: %v", err)
+	}
+	if target.HostHeader != "192.168.10.70.nip.io" {
+		t.Fatalf("unexpected host header after target round trip: %s", target.HostHeader)
 	}
 }
 

--- a/pkg/tunnel/client.go
+++ b/pkg/tunnel/client.go
@@ -200,7 +200,7 @@ func newTargetReverseProxy(upstream *url.URL, target Target) *httputil.ReversePr
 	}
 	proxy.Transport = &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		DialContext:           dialHTTPUpstreamContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
@@ -212,6 +212,36 @@ func newTargetReverseProxy(upstream *url.URL, target Target) *httputil.ReversePr
 		WriteUnavailablePage(w, target.URL, fmt.Sprintf("The configured target could not be reached by the local Sealtun client: %v", err))
 	}
 	return proxy
+}
+
+type dialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+var nativeHTTPUpstreamDialContext dialContextFunc = (&net.Dialer{
+	Timeout:   10 * time.Second,
+	KeepAlive: 30 * time.Second,
+}).DialContext
+
+var fallbackHTTPUpstreamDialContext = dialSystemNCContext
+
+func dialHTTPUpstreamContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := nativeHTTPUpstreamDialContext(ctx, network, address)
+	if err == nil {
+		return conn, nil
+	}
+	if shouldFallbackToSystemNC(err) {
+		return fallbackHTTPUpstreamDialContext(ctx, network, address, err)
+	}
+	return nil, err
+}
+
+func shouldFallbackToSystemNC(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no route to host") ||
+		strings.Contains(message, "network is unreachable") ||
+		strings.Contains(message, "host is down")
 }
 
 func isHTTPUpgrade(req *http.Request) bool {

--- a/pkg/tunnel/client.go
+++ b/pkg/tunnel/client.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -125,6 +127,11 @@ func handleLocalForwarding(stream net.Conn, localPort, protocol string) {
 func handleTargetForwarding(stream net.Conn, target Target, protocol string) {
 	defer stream.Close()
 
+	if tunnelprotocol.IsHTTP(protocol) && target.Explicit {
+		proxyHTTPStream(stream, target)
+		return
+	}
+
 	targetConn, err := dialTarget(target)
 	if err != nil {
 		warningMu.Lock()
@@ -142,6 +149,153 @@ func handleTargetForwarding(stream net.Conn, target Target, protocol string) {
 	defer targetConn.Close()
 
 	_ = relayBidirectional(targetConn, stream, nil)
+}
+
+func proxyHTTPStream(stream net.Conn, target Target) {
+	upstream, err := url.Parse(target.URL)
+	if err != nil {
+		_, _ = io.WriteString(stream, unavailableResponse(target.URL))
+		return
+	}
+
+	proxy := newTargetReverseProxy(upstream, target)
+	listener := singleConnListener{conn: stream, done: make(chan struct{})}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isHTTPUpgrade(r) {
+			defer listener.Close()
+		}
+		proxy.ServeHTTP(w, r)
+	})
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	server.SetKeepAlivesEnabled(false)
+	server.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			_ = listener.Close()
+		}
+	}
+	err = server.Serve(&listener)
+	if err != nil && err != http.ErrServerClosed && !expectedRelayClose(err) {
+		fmt.Printf("target proxy error for %s: %v\n", target.URL, err)
+	}
+}
+
+func newTargetReverseProxy(upstream *url.URL, target Target) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(upstream)
+	originalDirector := proxy.Director
+	upstreamPath := upstream.Path
+	upstreamRawPath := upstream.EscapedPath()
+	proxy.Director = func(req *http.Request) {
+		incomingPath := req.URL.Path
+		incomingRawPath := req.URL.EscapedPath()
+		originalDirector(req)
+		req.URL.Scheme = upstream.Scheme
+		req.URL.Host = upstream.Host
+		req.URL.Path = joinTargetPath(upstreamPath, incomingPath)
+		req.URL.RawPath = joinTargetRawPath(upstreamRawPath, incomingRawPath, req.URL.Path)
+		req.Host = target.HostHeader
+	}
+	proxy.Transport = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		fmt.Printf("target proxy error for %s: %v\n", target.URL, err)
+		WriteUnavailablePage(w, target.URL, fmt.Sprintf("The configured target could not be reached by the local Sealtun client: %v", err))
+	}
+	return proxy
+}
+
+func isHTTPUpgrade(req *http.Request) bool {
+	if req.Header.Get("Upgrade") == "" {
+		return false
+	}
+	for _, value := range req.Header.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func joinTargetPath(basePath, requestPath string) string {
+	if basePath == "" || basePath == "/" {
+		if requestPath == "" {
+			return "/"
+		}
+		return requestPath
+	}
+	if requestPath == "" {
+		return basePath
+	}
+	if requestPath == "/" {
+		if strings.HasSuffix(basePath, "/") {
+			return basePath
+		}
+		return basePath + "/"
+	}
+	baseSlash := strings.HasSuffix(basePath, "/")
+	requestSlash := strings.HasPrefix(requestPath, "/")
+	switch {
+	case baseSlash && requestSlash:
+		return basePath + requestPath[1:]
+	case !baseSlash && !requestSlash:
+		return basePath + "/" + requestPath
+	default:
+		return basePath + requestPath
+	}
+}
+
+func joinTargetRawPath(basePath, requestPath, decodedPath string) string {
+	joined := joinTargetPath(basePath, requestPath)
+	unescaped, err := url.PathUnescape(joined)
+	if err != nil || unescaped != decodedPath {
+		return ""
+	}
+	if (&url.URL{Path: decodedPath}).EscapedPath() == joined {
+		return ""
+	}
+	return joined
+}
+
+type singleConnListener struct {
+	conn net.Conn
+	once sync.Once
+	stop sync.Once
+	done chan struct{}
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	var conn net.Conn
+	l.once.Do(func() {
+		conn = l.conn
+	})
+	if conn != nil {
+		return conn, nil
+	}
+	<-l.done
+	return nil, net.ErrClosed
+}
+
+func (l *singleConnListener) Close() error {
+	l.stop.Do(func() {
+		close(l.done)
+	})
+	return nil
+}
+
+func (l *singleConnListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
 }
 
 func dialTarget(target Target) (net.Conn, error) {

--- a/pkg/tunnel/client_test.go
+++ b/pkg/tunnel/client_test.go
@@ -1,8 +1,13 @@
 package tunnel
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -137,4 +142,314 @@ func TestRawTCPLocalForwardingKeepsResponseAfterClientHalfClose(t *testing.T) {
 
 	<-forwardDone
 	<-localDone
+}
+
+func TestHTTPLocalForwardingKeepsRawRelayForImplicitTargets(t *testing.T) {
+	t.Parallel()
+
+	localListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer localListener.Close()
+
+	upstreamDone := make(chan struct{})
+	go func() {
+		defer close(upstreamDone)
+		conn, err := localListener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		var request strings.Builder
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			request.WriteString(line)
+			if line == "\r\n" {
+				break
+			}
+		}
+		if strings.Contains(request.String(), "Host: public.example") {
+			_, _ = conn.Write([]byte("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"))
+		}
+	}()
+
+	_, port, err := net.SplitHostPort(localListener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := TargetFor(port, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Explicit {
+		t.Fatal("expected implicit local target")
+	}
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTargetForwarding(server, target, tunnelprotocol.HTTPS)
+	}()
+
+	request := "GET /local HTTP/1.1\r\n" +
+		"Host: public.example\r\n" +
+		"Connection: close\r\n\r\n"
+	if _, err := client.Write([]byte(request)); err != nil {
+		t.Fatal(err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	response, err := io.ReadAll(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = client.Close()
+	<-done
+	<-upstreamDone
+
+	if !strings.Contains(string(response), "HTTP/1.1 204 No Content") {
+		t.Fatalf("expected raw upstream response, got %q", string(response))
+	}
+}
+
+func TestHTTPTargetForwardingUsesReverseProxyForExplicitTargets(t *testing.T) {
+	t.Parallel()
+
+	type observedRequest struct {
+		method string
+		path   string
+		query  string
+		host   string
+		body   string
+	}
+	observed := make(chan observedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		observed <- observedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			query:  r.URL.RawQuery,
+			host:   r.Host,
+			body:   string(body),
+		}
+		w.Header().Set("X-Upstream", "ok")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, "proxied:%s:%s", r.Method, body)
+	}))
+	defer upstream.Close()
+
+	target, err := TargetFor("", upstream.URL+"/base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTargetForwarding(server, target, tunnelprotocol.HTTPS)
+	}()
+
+	request := "POST /v1/items?debug=true HTTP/1.1\r\n" +
+		"Host: public.example\r\n" +
+		"Content-Length: 7\r\n" +
+		"\r\n" +
+		"payload"
+	if _, err := client.Write([]byte(request)); err != nil {
+		t.Fatal(err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	response, err := io.ReadAll(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = client.Close()
+	<-done
+
+	text := string(response)
+	if !strings.Contains(text, "HTTP/1.1 201 Created") {
+		t.Fatalf("expected upstream status, got %q", text)
+	}
+	if !strings.Contains(text, "X-Upstream: ok") {
+		t.Fatalf("expected upstream header, got %q", text)
+	}
+	if !bytes.Contains(response, []byte("proxied:POST:payload")) {
+		t.Fatalf("expected upstream body, got %q", text)
+	}
+
+	select {
+	case got := <-observed:
+		if got.method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", got.method)
+		}
+		if got.path != "/base/v1/items" || got.query != "debug=true" {
+			t.Fatalf("unexpected upstream route: path=%q query=%q", got.path, got.query)
+		}
+		if got.host != target.HostHeader {
+			t.Fatalf("expected target host %q, got %q", target.HostHeader, got.host)
+		}
+		if got.body != "payload" {
+			t.Fatalf("unexpected body: %q", got.body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("upstream did not receive request")
+	}
+}
+
+func TestHTTPTargetForwardingPreservesPUTMethodAndBody(t *testing.T) {
+	t.Parallel()
+
+	observed := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		observed <- r.Method + ":" + r.URL.Path + ":" + string(body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	target, err := TargetFor("", upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTargetForwarding(server, target, tunnelprotocol.HTTPS)
+	}()
+
+	request := "PUT /settings HTTP/1.1\r\n" +
+		"Host: public.example\r\n" +
+		"Content-Length: 11\r\n" +
+		"\r\n" +
+		"new-setting"
+	if _, err := client.Write([]byte(request)); err != nil {
+		t.Fatal(err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	response, err := io.ReadAll(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = client.Close()
+	<-done
+
+	if !strings.Contains(string(response), "HTTP/1.1 204 No Content") {
+		t.Fatalf("expected upstream status, got %q", string(response))
+	}
+	select {
+	case got := <-observed:
+		if got != "PUT:/settings:new-setting" {
+			t.Fatalf("unexpected upstream request: %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("upstream did not receive request")
+	}
+}
+
+func TestHTTPTargetForwardingSupportsUpgradeResponses(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isHTTPUpgrade(r) {
+			t.Fatalf("expected upgrade request")
+		}
+		conn, rw, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			t.Errorf("hijack upstream: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _ = rw.WriteString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: echo\r\nConnection: Upgrade\r\n\r\n")
+		if err := rw.Flush(); err != nil {
+			t.Errorf("flush upgrade response: %v", err)
+			return
+		}
+		line, err := rw.ReadString('\n')
+		if err != nil {
+			t.Errorf("read upgraded payload: %v", err)
+			return
+		}
+		_, _ = rw.WriteString("echo:" + line)
+		_ = rw.Flush()
+	}))
+	defer upstream.Close()
+
+	target, err := TargetFor("", upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTargetForwarding(server, target, tunnelprotocol.HTTPS)
+	}()
+
+	request := "GET /socket HTTP/1.1\r\n" +
+		"Host: public.example\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: echo\r\n\r\n"
+	if _, err := client.Write([]byte(request)); err != nil {
+		t.Fatal(err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	header := make([]byte, 256)
+	n, err := client.Read(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(header[:n]), "101 Switching Protocols") {
+		t.Fatalf("expected 101 response, got %q", string(header[:n]))
+	}
+	if _, err := client.Write([]byte("ping\n")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 32)
+	n, err = client.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "echo:ping\n" {
+		t.Fatalf("unexpected upgraded payload: %q", string(buf[:n]))
+	}
+	_ = client.Close()
+	<-done
+}
+
+func TestJoinTargetPathPreservesRouteShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		base string
+		req  string
+		want string
+	}{
+		{base: "/base", req: "/v1/items", want: "/base/v1/items"},
+		{base: "/base/", req: "/v1/items", want: "/base/v1/items"},
+		{base: "/base", req: "/", want: "/base/"},
+		{base: "/base", req: "/v1//items", want: "/base/v1//items"},
+		{base: "/base", req: "/v1/../items", want: "/base/v1/../items"},
+	}
+
+	for _, tt := range tests {
+		got := joinTargetPath(tt.base, tt.req)
+		if got != tt.want {
+			t.Fatalf("joinTargetPath(%q, %q) = %q, want %q", tt.base, tt.req, got, tt.want)
+		}
+	}
+}
+
+func TestJoinTargetRawPathPreservesEncodedSegments(t *testing.T) {
+	t.Parallel()
+
+	decoded := joinTargetPath("/base", "/files/a/b")
+	raw := joinTargetRawPath("/base", "/files/a%2Fb", decoded)
+
+	if raw != "/base/files/a%2Fb" {
+		t.Fatalf("unexpected raw path: %q", raw)
+	}
 }

--- a/pkg/tunnel/client_test.go
+++ b/pkg/tunnel/client_test.go
@@ -3,6 +3,8 @@ package tunnel
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -418,6 +420,68 @@ func TestHTTPTargetForwardingSupportsUpgradeResponses(t *testing.T) {
 	}
 	_ = client.Close()
 	<-done
+}
+
+func TestHTTPUpstreamDialFallsBackForNoRouteErrors(t *testing.T) {
+	oldNative := nativeHTTPUpstreamDialContext
+	oldFallback := fallbackHTTPUpstreamDialContext
+	defer func() {
+		nativeHTTPUpstreamDialContext = oldNative
+		fallbackHTTPUpstreamDialContext = oldFallback
+	}()
+
+	nativeErr := errors.New("dial tcp 192.168.10.70:443: connect: no route to host")
+	nativeHTTPUpstreamDialContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, nativeErr
+	}
+	fallbackCalled := false
+	fallbackHTTPUpstreamDialContext = func(_ context.Context, network, address string, got error) (net.Conn, error) {
+		fallbackCalled = true
+		if got != nativeErr {
+			t.Fatalf("expected original error, got %v", got)
+		}
+		if network != "tcp" || address != "192.168.10.70:443" {
+			t.Fatalf("unexpected dial target: network=%s address=%s", network, address)
+		}
+		server, client := net.Pipe()
+		t.Cleanup(func() {
+			_ = server.Close()
+			_ = client.Close()
+		})
+		return client, nil
+	}
+
+	conn, err := dialHTTPUpstreamContext(context.Background(), "tcp", "192.168.10.70:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	if !fallbackCalled {
+		t.Fatal("expected fallback dialer to be called")
+	}
+}
+
+func TestHTTPUpstreamDialDoesNotFallbackForOtherErrors(t *testing.T) {
+	oldNative := nativeHTTPUpstreamDialContext
+	oldFallback := fallbackHTTPUpstreamDialContext
+	defer func() {
+		nativeHTTPUpstreamDialContext = oldNative
+		fallbackHTTPUpstreamDialContext = oldFallback
+	}()
+
+	nativeErr := errors.New("dial tcp 10.0.0.12:443: connect: connection refused")
+	nativeHTTPUpstreamDialContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, nativeErr
+	}
+	fallbackHTTPUpstreamDialContext = func(context.Context, string, string, error) (net.Conn, error) {
+		t.Fatal("fallback should not be called")
+		return nil, nil
+	}
+
+	_, err := dialHTTPUpstreamContext(context.Background(), "tcp", "10.0.0.12:443")
+	if !errors.Is(err, nativeErr) {
+		t.Fatalf("expected original error, got %v", err)
+	}
 }
 
 func TestJoinTargetPathPreservesRouteShape(t *testing.T) {

--- a/pkg/tunnel/system_nc_dial_darwin.go
+++ b/pkg/tunnel/system_nc_dial_darwin.go
@@ -1,0 +1,126 @@
+//go:build darwin
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+func dialSystemNCContext(ctx context.Context, network, address string, nativeErr error) (net.Conn, error) {
+	if network != "tcp" && network != "tcp4" {
+		return nil, nativeErr
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, nativeErr
+	}
+	if host == "" || port == "" {
+		return nil, nativeErr
+	}
+	if len(host) > 0 && host[0] == '-' {
+		return nil, nativeErr
+	}
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/nc", host, port)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%w; system nc fallback setup failed: %v", nativeErr, err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%w; system nc fallback setup failed: %v", nativeErr, err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%w; system nc fallback setup failed: %v", nativeErr, err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("%w; system nc fallback failed: %v", nativeErr, err)
+	}
+	go func() {
+		_, _ = io.Copy(io.Discard, stderr)
+	}()
+
+	return &systemNCConn{
+		stdout: stdout,
+		stdin:  stdin,
+		cmd:    cmd,
+		local:  systemNCAddr("system-nc"),
+		remote: systemNCAddr(address),
+	}, nil
+}
+
+type systemNCConn struct {
+	stdout io.ReadCloser
+	stdin  io.WriteCloser
+	cmd    *exec.Cmd
+	once   sync.Once
+	local  net.Addr
+	remote net.Addr
+	err    error
+}
+
+func (c *systemNCConn) Read(p []byte) (int, error) {
+	return c.stdout.Read(p)
+}
+
+func (c *systemNCConn) Write(p []byte) (int, error) {
+	return c.stdin.Write(p)
+}
+
+func (c *systemNCConn) Close() error {
+	c.once.Do(func() {
+		_ = c.stdin.Close()
+		_ = c.stdout.Close()
+		if c.cmd.Process != nil {
+			_ = c.cmd.Process.Kill()
+		}
+		c.err = c.cmd.Wait()
+	})
+	return c.err
+}
+
+func (c *systemNCConn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c *systemNCConn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+func (c *systemNCConn) SetDeadline(deadline time.Time) error {
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(deadline)
+}
+
+func (c *systemNCConn) SetReadDeadline(deadline time.Time) error {
+	if setter, ok := c.stdout.(interface{ SetReadDeadline(time.Time) error }); ok {
+		return setter.SetReadDeadline(deadline)
+	}
+	return nil
+}
+
+func (c *systemNCConn) SetWriteDeadline(deadline time.Time) error {
+	if setter, ok := c.stdin.(interface{ SetWriteDeadline(time.Time) error }); ok {
+		return setter.SetWriteDeadline(deadline)
+	}
+	return nil
+}
+
+type systemNCAddr string
+
+func (a systemNCAddr) Network() string {
+	return "tcp"
+}
+
+func (a systemNCAddr) String() string {
+	return string(a)
+}

--- a/pkg/tunnel/system_nc_dial_other.go
+++ b/pkg/tunnel/system_nc_dial_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package tunnel
+
+import (
+	"context"
+	"net"
+)
+
+func dialSystemNCContext(_ context.Context, _, _ string, nativeErr error) (net.Conn, error) {
+	return nil, nativeErr
+}

--- a/pkg/tunnel/target.go
+++ b/pkg/tunnel/target.go
@@ -9,9 +9,11 @@ import (
 )
 
 type Target struct {
-	URL     string
-	Address string
-	Port    string
+	URL        string
+	Address    string
+	Port       string
+	HostHeader string
+	Explicit   bool
 }
 
 func LocalhostTarget(localPort string) (Target, error) {
@@ -44,9 +46,6 @@ func ParseTarget(raw string) (Target, error) {
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return Target{}, fmt.Errorf("target must not include query or fragment")
 	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		return Target{}, fmt.Errorf("target path is not supported")
-	}
 	port := parsed.Port()
 	if port == "" {
 		if scheme == "https" {
@@ -60,18 +59,37 @@ func ParseTarget(raw string) (Target, error) {
 		return Target{}, fmt.Errorf("target port must be between 1 and 65535")
 	}
 	parsed.Scheme = scheme
+	hostHeader := targetHostHeader(parsed.Hostname(), scheme, port)
 	parsed.Host = net.JoinHostPort(parsed.Hostname(), port)
-	parsed.Path = ""
+	if parsed.Path == "/" {
+		parsed.Path = ""
+	}
 	return Target{
-		URL:     parsed.String(),
-		Address: parsed.Host,
-		Port:    port,
+		URL:        parsed.String(),
+		Address:    parsed.Host,
+		Port:       port,
+		HostHeader: hostHeader,
 	}, nil
+}
+
+func targetHostHeader(host, scheme, port string) string {
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		if strings.Contains(host, ":") {
+			return "[" + host + "]"
+		}
+		return host
+	}
+	return net.JoinHostPort(host, port)
 }
 
 func TargetFor(localPort, targetURL string) (Target, error) {
 	if strings.TrimSpace(targetURL) != "" {
-		return ParseTarget(targetURL)
+		target, err := ParseTarget(targetURL)
+		if err != nil {
+			return Target{}, err
+		}
+		target.Explicit = true
+		return target, nil
 	}
 	return LocalhostTarget(localPort)
 }

--- a/pkg/tunnel/target_test.go
+++ b/pkg/tunnel/target_test.go
@@ -15,6 +15,9 @@ func TestParseTargetNormalizesHTTPUpstream(t *testing.T) {
 	if target.Address != "10.0.0.12:8080" || target.Port != "8080" {
 		t.Fatalf("unexpected target: %#v", target)
 	}
+	if target.HostHeader != "10.0.0.12:8080" {
+		t.Fatalf("unexpected host header: %s", target.HostHeader)
+	}
 }
 
 func TestParseTargetAppliesDefaultPorts(t *testing.T) {
@@ -27,6 +30,9 @@ func TestParseTargetAppliesDefaultPorts(t *testing.T) {
 	if httpTarget.URL != "http://api.internal:80" {
 		t.Fatalf("unexpected http url: %s", httpTarget.URL)
 	}
+	if httpTarget.HostHeader != "api.internal" {
+		t.Fatalf("unexpected http host header: %s", httpTarget.HostHeader)
+	}
 
 	httpsTarget, err := ParseTarget("https://api.internal")
 	if err != nil {
@@ -35,14 +41,36 @@ func TestParseTargetAppliesDefaultPorts(t *testing.T) {
 	if httpsTarget.URL != "https://api.internal:443" {
 		t.Fatalf("unexpected https url: %s", httpsTarget.URL)
 	}
+	if httpsTarget.HostHeader != "api.internal" {
+		t.Fatalf("unexpected https host header: %s", httpsTarget.HostHeader)
+	}
+
+	httpsExplicitDefaultPortTarget, err := ParseTarget("https://api.internal:443")
+	if err != nil {
+		t.Fatalf("parse https target with explicit default port: %v", err)
+	}
+	if httpsExplicitDefaultPortTarget.HostHeader != "api.internal" {
+		t.Fatalf("unexpected https explicit default-port host header: %s", httpsExplicitDefaultPortTarget.HostHeader)
+	}
 }
 
-func TestParseTargetRejectsNonRootURL(t *testing.T) {
+func TestParseTargetPreservesSubRoute(t *testing.T) {
+	t.Parallel()
+
+	target, err := ParseTarget("https://api.internal/base/path")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+	if target.URL != "https://api.internal:443/base/path" {
+		t.Fatalf("unexpected url: %s", target.URL)
+	}
+}
+
+func TestParseTargetRejectsUnsupportedURLParts(t *testing.T) {
 	t.Parallel()
 
 	for _, raw := range []string{
 		"ftp://api.internal:21",
-		"http://api.internal:8080/path",
 		"http://api.internal:8080?token=secret",
 		"http://user:pass@api.internal:8080",
 	} {

--- a/skills/sealtun/references/cli.md
+++ b/skills/sealtun/references/cli.md
@@ -78,6 +78,7 @@ sealtun init --protocol auto --json
 sealtun init --protocol postgres --apply
 sealtun expose 3000
 sealtun expose --target http://10.0.0.12:8080
+sealtun expose --target https://10.0.0.12:8443/admin
 sealtun expose 3000 --foreground
 sealtun expose 3000 --ready-timeout 2m
 ```
@@ -86,7 +87,7 @@ sealtun expose 3000 --ready-timeout 2m
 
 Use `https` when the user wants a browser URL, webhook callback URL, OAuth callback, payment callback, public preview link, Basic Auth, Bearer tokens, temporary access links, IP allowlist/denylist, or custom domain.
 
-Use `--target` when the public HTTPS URL should forward to an existing HTTP/HTTPS upstream address instead of `localhost:<port>`. The target must be reachable from the machine running the Sealtun CLI. `--target` is rejected for `--protocol ssh` and `--protocol tcp`; those remain direct L4 local-port tunnels.
+Use `--target` when the public HTTPS URL should forward to an existing HTTP/HTTPS upstream address instead of `localhost:<port>`. The target must be reachable from the machine running the Sealtun CLI. A target path is treated as the upstream base path, so public `/api` forwards to `https://10.0.0.12:8443/admin/api`; targets must not include query, fragment, or userinfo. `--target` is rejected for `--protocol ssh` and `--protocol tcp`; those remain direct L4 local-port tunnels.
 
 ## Public Access Controls
 

--- a/skills/sealtun/references/declarative.md
+++ b/skills/sealtun/references/declarative.md
@@ -31,7 +31,7 @@ Use declarative config when the user wants repeatability, multiple tunnels, stab
 | Need | YAML choice | Check |
 | --- | --- | --- |
 | Stable HTTPS tunnel | `protocol: https`, `name`, `localPort` | `apply --dry-run`, `diff`, then `inspect` |
-| Remote HTTP upstream | `protocol: https`, `name`, `target: http://host:port` | target must be reachable from the Sealtun client machine |
+| Remote HTTP upstream | `protocol: https`, `name`, `target: http://host:port` | target must be reachable from the Sealtun client machine; optional path becomes the upstream base path |
 | Public SSH | `protocol: ssh`, `localPort: 22` | output must show SSH host and port |
 | Generic TCP/database | `protocol: tcp`, protocol-specific port | output must show `<host>:<port>` |
 | Auto-expire | `ttl: 2h` or similar Go duration | verify `expiresAt` behavior in output/session |
@@ -76,7 +76,7 @@ Remote HTTP upstream example:
 version: v1
 tunnels:
   - name: upstream-api
-    target: http://10.0.0.12:8080
+    target: https://10.0.0.12:8443/admin
     protocol: https
     accessPolicy:
       rateLimit: 60/m
@@ -89,9 +89,9 @@ tunnels:
 - `version` defaults to `v1`; only `v1` is supported.
 - `tunnels` must contain at least one item.
 - `name` is required, lower-case DNS-compatible, and becomes the stable tunnel ID. Reapplying the same name updates `sealtun-<name>`.
-- Use `localPort`; `port` is accepted as a compatibility alias. For HTTPS upstream forwarding, use `target: http://host:port` or `target: https://host:port` instead of `localPort`.
+- Use `localPort`; `port` is accepted as a compatibility alias. For HTTPS upstream forwarding, use `target: http://host:port` or `target: https://host:port/base` instead of `localPort`.
 - `protocol` defaults to `https`; `ssh` is supported for direct TCP NodePort SSH, and `tcp` is supported for generic direct TCP NodePort tunnels. HTTP-only features such as `domain`, `basicAuth`, and `accessPolicy` are rejected for `ssh` and `tcp`.
-- `target` is HTTPS-only. It must not include userinfo, path, query, or fragment. If `localPort` is also set, it must match the target port.
+- `target` is HTTPS-only. It may include a path as the upstream base path, but must not include userinfo, query, or fragment. If `localPort` is also set, it must match the target port.
 - `ttl` uses Go duration syntax like `30m`, `2h`, or `24h`.
 - `readyTimeout` and `domainTimeout` use Go duration syntax and must be positive.
 - Multiple tunnels are applied in one run. On an apply failure, Sealtun attempts rollback for tunnels changed earlier in the batch.

--- a/skills/sealtun/references/troubleshooting.md
+++ b/skills/sealtun/references/troubleshooting.md
@@ -118,7 +118,7 @@ curl -v http://127.0.0.1:3000/
 curl -v http://10.0.0.12:8080/
 ```
 
-Use `sealtun discover` when the user is unsure which local port is actually listening; it scans local TCP listening ports only and provides protocol/template hints without creating a tunnel. For `--target`, do not use discovery; verify the explicit upstream URL from the machine running Sealtun. Fix the local service or upstream reachability first. Sealtun forwards to `localhost:<localPort>` for local tunnels, or to `target` for HTTPS upstream tunnels.
+Use `sealtun discover` when the user is unsure which local port is actually listening; it scans local TCP listening ports only and provides protocol/template hints without creating a tunnel. For `--target`, do not use discovery; verify the explicit upstream URL from the machine running Sealtun. Fix the local service or upstream reachability first. Sealtun forwards to `localhost:<localPort>` for local tunnels, or reverse-proxies HTTP methods and bodies to `target` for HTTPS upstream tunnels. A path in `target` is treated as the upstream base path.
 
 ## Remote Kubernetes Or Pod Problems
 

--- a/skills/sealtun/references/troubleshooting.md
+++ b/skills/sealtun/references/troubleshooting.md
@@ -120,6 +120,8 @@ curl -v http://10.0.0.12:8080/
 
 Use `sealtun discover` when the user is unsure which local port is actually listening; it scans local TCP listening ports only and provides protocol/template hints without creating a tunnel. For `--target`, do not use discovery; verify the explicit upstream URL from the machine running Sealtun. Fix the local service or upstream reachability first. Sealtun forwards to `localhost:<localPort>` for local tunnels, or reverse-proxies HTTP methods and bodies to `target` for HTTPS upstream tunnels. A path in `target` is treated as the upstream base path.
 
+On macOS, some local network routes can be reachable through system tools such as `/usr/bin/nc` while Go's native socket dial returns `no route to host`. For explicit HTTP/HTTPS `--target` upstreams, Sealtun falls back to the system `nc` TCP carrier on that narrow error class so the Go HTTP reverse proxy can still complete TLS and request forwarding. If both native dial and the fallback fail, troubleshoot the machine's local network permission or routing state first.
+
 ## Remote Kubernetes Or Pod Problems
 
 Symptoms:


### PR DESCRIPTION
## Summary
- Reverse-proxy explicit HTTPS `--target` upstreams instead of raw TCP relaying them, so remote HTTP/HTTPS targets receive valid HTTP requests.
- Preserve upstream base paths, methods, bodies, query strings, encoded path segments, default-port Host behavior, and Upgrade/101 flows.
- Add a narrow macOS fallback for explicit HTTP/HTTPS targets where Go native sockets return `no route to host` but `/usr/bin/nc` can reach the same local-network upstream; Go still owns TLS and HTTP forwarding over that TCP carrier.
- Document target path semantics and the macOS fallback troubleshooting note.

## Tests
- `go test ./pkg/tunnel ./cmd`
- `go test ./...`
- `go build -o /tmp/sealtun-http-target-test main.go`
- `git diff --check`
- `go vet ./...`
- `node --check scripts/build-npm-packages.mjs`
- `GOOS=linux GOARCH=amd64 go test -c ./pkg/tunnel -o /tmp/sealtun-tunnel-linux-amd64.test`

## Real Target Verification
- Direct `curl` to `https://192.168.10.70.nip.io/` returned HTTP 200.
- Direct login POST to `https://192.168.10.70.nip.io/api/auth/password` returned HTTP 200 with a token present.
- Before the macOS fallback, `sealtun expose --foreground --target https://192.168.10.70.nip.io/` established the tunnel but public requests returned 502 because the local Go client process failed to dial `192.168.10.70:443` with `connect: no route to host`.
- After the fallback, the same Sealtun public URL returned HTTP 200 for `/`, and `POST /api/auth/password` through the public URL returned HTTP 200 with a token present.