### PR TITLE
fix(auth): update GetInitData endpoint for new Sealos API

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -300,7 +300,7 @@ func GetInitData(region string) (*InitDataResponse, error) {
 	if host == "" {
 		return nil, fmt.Errorf("invalid region %q", region)
 	}
-	apiURL := fmt.Sprintf("https://applaunchpad.%s/api/platform/getInitData", u.Host)
+	apiURL := fmt.Sprintf("https://kubepanel.%s/api/platform/init-data", u.Host)
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`sealtun login` fails after OAuth authorization with:

```
failed to get region init data: get init data failed (404): <!DOCTYPE html>...
```

The 404 page is the Sealos AppLaunchpad Next.js 404 page.

## Root Cause

The init data API used by `GetInitData` in `pkg/auth/auth.go` is stale:

- Old: `https://applaunchpad.<region>/api/platform/getInitData`
- New: `https://kubepanel.<region>/api/platform/init-data`

The endpoint has moved from the applaunchpad provider to the kubepanel provider, and the path has changed from `getInitData` to `init-data`.

## Verification

Tested across all built-in regions:

```bash
curl https://kubepanel.gzg.sealos.run/api/platform/init-data
# {"code":200,"data":{"SEALOS_DOMAIN":"gzg.sealos.run"}}

curl https://kubepanel.hzh.sealos.run/api/platform/init-data
# {"code":200,"data":{"SEALOS_DOMAIN":"hzh.sealos.run"}}

curl https://kubepanel.bja.sealos.run/api/platform/init-data
# {"code":200,"data":{"SEALOS_DOMAIN":"bja.sealos.run"}}

curl https://kubepanel.cloud.sealos.io/api/platform/init-data
# {"code":200,"data":{"SEALOS_DOMAIN":"cloud.sealos.io"}}
```

## Change

Single line change in `pkg/auth/auth.go`:

```go
apiURL := fmt.Sprintf("https://kubepanel.%s/api/platform/init-data", u.Host)
```

The response format (`data.SEALOS_DOMAIN`) is unchanged, so no struct updates are needed.

## Tests

```bash
go test ./pkg/auth/... ./cmd/... -count=1
```

```
ok      github.com/labring/sealtun/pkg/auth    0.227s
ok      github.com/labring/sealtun/cmd    1.467s
```

All tests pass.

Fixes #3
